### PR TITLE
Feature/18 deployment fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,14 @@ jobs:
     - name: Tests
       run: |
         make test
-    - name: Build Package
+    - name: Build Package (Prod)
+      if: startsWith(github.ref, 'refs/tags')
       run: |
         make build
+    - name: Build Package (Test)
+      if: ${{ !startsWith(github.ref, 'refs/tags') }}
+      run: |
+        make build-test
     - name: Post to Splunk SOAR API
       run: |
         make deploy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: all build clean lint static
-MODULE:=illinois_app
-PACKAGE:=app
+# DO NOT EDIT
+# All project-specific values belong in config.mk!
 
+.PHONY: all build clean lint static
+include config.mk
+
+PACKAGE:=app
 SRCS_DIR:=src/ph$(MODULE)
 TSCS_DIR:=tests
 SOAR_SRCS:=$(shell find $(SRCS_DIR) -type f)
@@ -21,7 +24,13 @@ GITHUB_SHA?=$(shell git rev-parse HEAD)
 
 all: build
 
-build: $(PACKAGE).tgz
+build: export APP_ID=$(PROD_APP_ID)
+build: export APP_NAME=$(PROD_APP_NAME)
+build: .appjson $(PACKAGE).tgz
+
+build-test: export APP_ID=$(TEST_APP_ID)
+build-test: export APP_NAME=$(TEST_APP_NAME)
+build-test: .appjson $(PACKAGE).tgz
 
 $(PACKAGE).tgz: version $(SOAR_SRCS)
 	tar zcvf $@ -C src .
@@ -29,15 +38,21 @@ $(PACKAGE).tgz: version $(SOAR_SRCS)
 version: .tag .commit .deployed
 .tag: $(VERSIONED_FILES)
 	echo version $(TAG)
-	sed -i s/GITHUB_TAG/$(TAG)/ $^
+	sed -i "s/GITHUB_TAG/$(TAG)/" $^
 	touch $@
 .commit: $(VERSIONED_FILES)
 	echo commit $(GITHUB_SHA)
-	sed -i s/GITHUB_SHA/$(GITHUB_SHA)/ $^
+	sed -i "s/GITHUB_SHA/$(GITHUB_SHA)/" $^
 	touch $@
 .deployed: $(VERSIONED_FILES)
 	echo deployed $(BUILD_TIME)
-	sed -i s/BUILD_TIME/$(BUILD_TIME)/ $^
+	sed -i "s/BUILD_TIME/$(BUILD_TIME)/" $^
+	touch $@
+.appjson: $(SRCS_DIR)/$(PACKAGE).json
+	echo appid: $(APP_ID)
+	echo name:  $(APP_NAME)
+	sed -i "s/APP_ID/$(APP_ID)/" $^
+	sed -i "s/APP_NAME/$(APP_NAME)/" $^
 	touch $@
 
 deploy: $(PACKAGE).tgz

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,5 @@
+MODULE:=illinois_app
+PROD_APP_ID:=fc618bee-352f-461a-95b5-bc0a2395302a
+PROD_APP_NAME:=Test Template Repo
+TEST_APP_ID:=5e842053-7364-4a90-a275-2bd838458fef
+TEST_APP_NAME:=Test Box

--- a/first_run_check.sh
+++ b/first_run_check.sh
@@ -1,0 +1,25 @@
+# Exit on non-zero exit code
+set -e
+KEYS=(
+    MODULE
+    PROD_APP_ID
+    APP_NAME
+    TEST_APP_NAME
+    TODO
+)
+VALUES=(
+    illinois_app
+    fc618bee-352f-461a-95b5-bc0a2395302a
+    "Test Template Repo"
+    "Test Box"
+    TODO
+)
+for i in ${!VALUES[@]}; do 
+    if git grep "${VALUES[$i]}" -- :^first_run_check.sh
+    then
+        echo "Failed to update ${KEYS[$i]}!" && exit 1
+    fi
+done
+
+echo Remove first_run_check.sh
+exit 1

--- a/run_first_check.sh
+++ b/run_first_check.sh
@@ -21,5 +21,5 @@ for i in ${!VALUES[@]}; do
     fi
 done
 
-echo Remove first_run_check.sh
+echo Remove run_first_check.sh
 exit 1

--- a/src/phillinois_app/app.json
+++ b/src/phillinois_app/app.json
@@ -1,16 +1,16 @@
 {
-    "appid": "d65b6a0c-e423-40a5-b74d-c024e7397104",
-    "name": "TestBox",
+    "appid": "APP_ID",
+    "name": "APP_NAME",
     "description": "Illinois Test Template app",
     "type": "Cybersecurity incident response",
-    "product_vendor": "Tech Services Illinois",
     "logo": "logo.png",
     "logo_dark": "logo.png",
-    "product_name": "TestBox",
+    "product_vendor": "TODO - Add upstream product vendor",
+    "product_name": "TODO - Add upstream product name",
     "python_version": "3",
     "product_version_regex": ".*",
-    "publisher": "Cybersecurity",
-    "license": "Copyright (c) Cybersecurity, 2023",
+    "publisher": "University of Illinois Technology Services Cybersecurity",
+    "license": "NCSA",
     "app_version": "GITHUB_TAG",
     "utctime_updated": "BUILD_TIME",
     "package_name": "phIllinois_app",
@@ -66,5 +66,6 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "disabled": true
 }


### PR DESCRIPTION
- Add `build-test` step to create test app tgz with different UUID and name
- Add trivial `test_robots_txt` action block because an app with zero actions cannot be enabled
- Add config.mk for values that change when using this template
- Add `run_first_check.sh` to verify required changes when using this template
- Fix `app.json` publisher and vendor fields
 