### PR TITLE
Add instructions to find DEBUG logs in SOAR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ To emit a log into the SOAR debug logs, use `self.debug_print`:
 
     `self.debug_print("git_hash", __git_hash__)`
 
-To read SOAR app logs, visit SOAR `Administration` in the main drop-down, and look under `System Health` and then `Debugging`. 
+To read SOAR app DEBUG logs, visit SOAR `Administration` in the main drop-down, and look under `System Health` and then `Debugging`. 
 
 > Tip: You must have specific permissions assigned to your account to access this area.
 


### PR DESCRIPTION
Add instructions for finding debug log output on SOAR to CONTRIBUTING.md.

Closes #56