### PR TITLE
Update for latest phantom toolbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ app.tar: $(DIST_SRCS)
 	tar cvf $@ -C dist app
 
 deploy: app.tar venv
-	$(VENV_PYTHON) -m phtoolbox deploy --file $<
+	$(VENV_PYTHON) -m phtoolbox deploy $<
 
 python-version:
 	@echo $(SOAR_PYTHON_VERSION)


### PR DESCRIPTION
Update to match phantom toolbox. We retired `--file` from `deploy` and made it positional, since the payload is not optional.