### PR TITLE
Add MyPy exception resource to mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,7 @@
 # DO NOT EDIT - Update techservicesillinois/splunk-soar-template first
+# This file contains shared MyPy config for all SOAR projects.
+# Add project specific MyPy as inline code comments.
+# See https://mypy.readthedocs.io/en/stable/common_issues.html#spurious-errors-and-locally-silencing-the-checker
 [mypy]
 
 warn_unused_configs = true


### PR DESCRIPTION
From [SOAR TDX 147#](https://github.com/techservicesillinois/secops-soar-tdx/pull/147)


Link to how to do inline code MyPy exceptions in MyPy.ini to help keep MyPy.ini in sync.

Per discussion in ensemble today.