### PR TITLE
Add warning when more than one action is type test. Test type actions…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ check_template_contents:
 	@ ! grep -ql MODULE src/app/app.json || echo "app.json should not contain MODULE. Change MODULE to app."
 	@ python -c "import json, sys; d=json.load(open('src/app/app.json')); sys.exit(0) if d.get('python_version') == '3.13' else print('app.json: python_version must be set to 3.13.') or sys.exit(1)"
 	@ ! grep -ql '"pip[0-9]*_dependencies"' src/app/app.json || echo "app.json should not contain pip dependencies. phantom_toolbox will manage dependencies."
+	@ (grep -c '"type": "test"' src/app/app.json | grep -q 1) || echo "app.json should not contain multiple test actions"
 
 test: lint static check_template unit
 


### PR DESCRIPTION
## Context

Our domain block actions were not appearing in the playbook editor, because actions with type 'test' do not appear in playbooks. It's easy for the 'test' type to get copied around when we base a new action `json` block on `test_connectivity`.

This update warns us if more than one action in `app.json` is marked as type test.

